### PR TITLE
Augment Object Detail Links

### DIFF
--- a/genericadmin/admin.py
+++ b/genericadmin/admin.py
@@ -18,9 +18,10 @@ try:
     from django.contrib.admin.views.main import IS_POPUP_VAR
 except ImportError:
     from django.contrib.admin.options import IS_POPUP_VAR
-from  django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import ObjectDoesNotExist
 
 JS_PATH = getattr(settings, 'GENERICADMIN_JS', 'genericadmin/js/')
+
 
 class BaseGenericModelAdmin(object):
     class Media:
@@ -138,6 +139,11 @@ class BaseGenericModelAdmin(object):
             try:
                 obj = content_type.get_object_for_this_type(pk=object_id)
                 obj_dict["object_text"] = capfirst(force_text(obj))
+                try:
+                    absolute_url = obj.get_absolute_url()
+                except (AttributeError,):
+                    absolute_url = ''
+                obj_dict["absolute_url"] = absolute_url
             except ObjectDoesNotExist:
                 raise Http404
 
@@ -145,7 +151,6 @@ class BaseGenericModelAdmin(object):
         else:
             resp = ''
         return HttpResponse(resp, content_type='application/json')
-
 
 
 class GenericAdminModelAdmin(BaseGenericModelAdmin, admin.ModelAdmin):

--- a/genericadmin/static/genericadmin/js/genericadmin.js
+++ b/genericadmin/static/genericadmin/js/genericadmin.js
@@ -112,7 +112,7 @@
                 link = '<a class="related-lookup" id="' + id + '" href="' + url + '">';
 
             link = link + '<img src="' + this.admin_media_url.replace(/\/?$/, '/') + 'img/selector-search.gif" style="cursor: pointer; margin-left: 5px; margin-right: 10px;" width="16" height="16" alt="Lookup"></a>';
-            link = link + '<strong id="lookup_text_'+ this.getFkId() +'" margin-left: 5px"><a target="_new" href="#"></a><span></span></strong>';
+            link = link + '<strong id="lookup_text_'+ this.getFkId() +'" margin-left: 5px"><span></span><a target="_new" class="edit-link" href="#" style="display:inline-block;margin-left:10px;"></a><a href="#" target="_new" class="view-link" style="display:inline-block;margin-left:10px;"></a></strong>';
 
             // insert link html after input element
             this.object_input.after(link);
@@ -177,9 +177,20 @@
                     success: function(item) {
                         if (item && item.content_type_text && item.object_text) {
                             var url = that.getLookupUrl(that.cID, false);
-                            $('#lookup_text_' + that.getFkId() + ' a')
-                                .text(item.content_type_text + ': ' + item.object_text)
-                                .attr('href', url + item.object_id);
+
+                            // object description
+                            $('#lookup_text_' + that.getFkId() + ' span')
+                                .text(item.content_type_text + ': ' + item.object_text);
+
+                            // Link to edit object
+                            $('#lookup_text_' + that.getFkId() + ' .edit-link')
+                                .text('Edit').attr('href', url + item.object_id);
+
+                            // Link to view object
+                            if (item.absolute_url) {
+                                $('#lookup_text_' + that.getFkId() + ' .view-link')
+                                    .text('View').attr('href', item.absolute_url);
+                            }
 
                             // run a callback to do other stuff like prepopulating url fields
                             // can't be done with normal django admin prepopulate
@@ -187,7 +198,6 @@
                                 that.updateObjectDataCallback(item);
                             }
                         }
-                        $('#lookup_text_' + that.getFkId() + ' span').text('');
                     },
                     error: function(xhr, status, error) {
                         $('#lookup_text_' + that.getFkId() + ' span').text('')


### PR DESCRIPTION
The purpose of this pull request is to augment the object details returned from a generic lookup so that there are two links:
- One to edit the object
- One to view the object via it's `absolute_url` if present
## Work
- Added absolute_url for object to values returned in generic_lookup view.
- Refactored JavaScript links and text for object retrieved to display the model, unicode representation of the object, a link to edit the object and a link to the absolute url of the object.
- Minor PEP8 fixes
## Result

![advocacy article - google chrome_004](https://cloud.githubusercontent.com/assets/86738/11124898/37504498-8935-11e5-867a-cce6e8c5fe7a.jpg)
